### PR TITLE
Bot déplacés

### DIFF
--- a/_data/directory.yml
+++ b/_data/directory.yml
@@ -50,7 +50,7 @@
     - mirrors
     - news
 
-"lexpress@framapiaf.org":
+"lexpressbot@friends.nico":
   name: "L'Express"
   lang: fr
   tags:
@@ -841,7 +841,7 @@
       - technology
 
 
-"courrierinter@framapiaf.org":
+"courrierinterbot@friends.nico":
   name: Courrier International
   lang: fr
   tags:
@@ -858,7 +858,7 @@
     - science
 
 
-"FossoyeurDeFilms@framapiaf.org":
+"FossoyeurdeFilms@friends.nico":
   name: Le Fossoyeur de Films
   lang: fr
   tags:


### PR DESCRIPTION
lemonde à aussi été déplacé mais 404 sur la [destination](https://friends.nico/@lemondebot) et les autres bots (du monde) trouvables en recherchant sont inactifs depuis plusieurs mois.